### PR TITLE
s/newInstance()/getDeclaredConstructor().newInstance()

### DIFF
--- a/sbt-reladomo-plugin/src/main/scala/com/folio_sec/reladomo/generator/sbtplugin/ReladomoPlugin.scala
+++ b/sbt-reladomo-plugin/src/main/scala/com/folio_sec/reladomo/generator/sbtplugin/ReladomoPlugin.scala
@@ -87,15 +87,15 @@ object ReladomoPlugin extends AutoPlugin {
     Def.task {
       val dbDefinitionGeneratorFactory: DbDefinitionGeneratorFactory = {
         val clazz = Class.forName(reladomoDbDefinitionGeneratorFactoryClassName.value)
-        clazz.newInstance().asInstanceOf[DbDefinitionGeneratorFactory]
+        clazz.getDeclaredConstructor().newInstance().asInstanceOf[DbDefinitionGeneratorFactory]
       }
       val javaCodeGeneratorFactory: JavaCodeGeneratorFactory = {
         val clazz = Class.forName(reladomoJavaCodeGeneratorFactoryClassName.value)
-        clazz.newInstance().asInstanceOf[JavaCodeGeneratorFactory]
+        clazz.getDeclaredConstructor().newInstance().asInstanceOf[JavaCodeGeneratorFactory]
       }
       val scalaCodeGeneratorFactory: ScalaCodeGeneratorFactory = {
         val clazz = Class.forName(reladomoScalaCodeGeneratorFactoryClassName.value)
-        clazz.newInstance().asInstanceOf[ScalaCodeGeneratorFactory]
+        clazz.getDeclaredConstructor().newInstance().asInstanceOf[ScalaCodeGeneratorFactory]
       }
 
       val classListXmlFiles: Seq[File] = {


### PR DESCRIPTION
`java.lang.Class#newInstance` deprecated since Java 9

http://download.java.net/java/jdk9/docs/api/java/lang/Class.html#newInstance--
