### PR TITLE
Bump Reladomo version from 16.5 to 16.6, also other minor upgrades

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
 
   lazy val twitterUtilVersion    = sys.env.get("TWITTER_UTIL_VERSION").getOrElse("6.45.0")
   lazy val twitterUtilBinVersion = toBinV(twitterUtilVersion)
-  lazy val reladomoVersion     = "16.5.1"
+  lazy val reladomoVersion     = "16.6.1"
   lazy val reladomoBinVersion = toBinV(reladomoVersion)
 
   lazy val reladomo        = "com.goldmansachs.reladomo" % "reladomo" % reladomoVersion % Compile excludeAll(
@@ -21,8 +21,8 @@ object Dependencies {
   lazy val twitterUtilCore = "com.twitter"       %% "util-core"             % twitterUtilVersion % Compile
   lazy val slf4jApi        = "org.slf4j"         %  "slf4j-api"             % "1.7.25"  % Compile
   lazy val jodaTime        = "joda-time"         %  "joda-time"             % "2.9.9"   % Compile
-  lazy val jodaConvert     = "org.joda"          %  "joda-convert"          % "1.8.2"   % Compile
-  lazy val scalikejdbc     = "org.scalikejdbc"   %% "scalikejdbc"           % "3.0.2"   % Test
+  lazy val jodaConvert     = "org.joda"          %  "joda-convert"          % "1.9.2"   % Compile
+  lazy val scalikejdbc     = "org.scalikejdbc"   %% "scalikejdbc"           % "3.1.0"   % Test
   lazy val h2              = "com.h2database"    %  "h2"                    % "1.4.196" % Test
   lazy val logbackClassic  = "ch.qos.logback"    %  "logback-classic"       % "1.2.3"   % Test
   // reladomo generator depends on ant

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 libraryDependencies += "org.scala-sbt" % "scripted-plugin" % sbtVersion.value
 
-addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.0-RC11")
-addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"    % "1.10")
+addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.0-RC12")
+addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"    % "1.12")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.1.17")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"     % "0.3.1")
 addSbtPlugin("net.virtual-void"  % "sbt-dependency-graph" % "0.8.2")

--- a/publish_local.sh
+++ b/publish_local.sh
@@ -3,5 +3,6 @@ sbt clean "project reladomoScalaCommon" +publishLocal
 export TWITTER_UTIL_VERSION=6.43.0;sbt clean "project reladomoScalaTwitterCommon" +publishLocal
 export TWITTER_UTIL_VERSION=6.45.0;sbt clean "project reladomoScalaTwitterCommon" +publishLocal
 export TWITTER_UTIL_VERSION=7.0.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
+export TWITTER_UTIL_VERSION=7.1.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
 
 sbt clean "project sbtReladomoPlugin" "^publishLocal"

--- a/sample/build.sbt
+++ b/sample/build.sbt
@@ -1,5 +1,5 @@
-lazy val reladomoScalaV  = sys.env.get("RELEASE_VERSION").getOrElse("16.5.7-SNAPSHOT")
-lazy val reladomoV       = "16.5.1"
+lazy val reladomoScalaV  = sys.env.get("RELEASE_VERSION").getOrElse("16.6.0-SNAPSHOT")
+lazy val reladomoV       = "16.6.1"
 lazy val twitterBinV     = "6.45"
 lazy val theOrganization = "com.folio-sec"
 

--- a/sample/project/plugins.sbt
+++ b/sample/project/plugins.sbt
@@ -1,6 +1,6 @@
 resolvers += "sonatype snapshots" at "https://oss.sonatype.org/content/repositories/snapshots"
-lazy val reladomoScalaV = sys.env.get("RELEASE_VERSION").getOrElse("16.5.7-SNAPSHOT")
+lazy val reladomoScalaV = sys.env.get("RELEASE_VERSION").getOrElse("16.6.0-SNAPSHOT")
 addSbtPlugin("com.folio-sec" % "sbt-reladomo-plugin" % reladomoScalaV)
 
-addSbtPlugin("com.lucidchart"  % "sbt-scalafmt" % "1.10")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC11")
+addSbtPlugin("com.lucidchart"  % "sbt-scalafmt" % "1.12")
+addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC12")

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
@@ -1,8 +1,8 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
-lazy val reladomoV            = "16.5.1"
-lazy val twitterUtilCoreBinV  = "6.45"
-lazy val theOrganization      = "com.folio-sec"
+lazy val reladomoV           = "16.6.1"
+lazy val twitterUtilCoreBinV = "6.45"
+lazy val theOrganization     = "com.folio-sec"
 
 lazy val root = (project in file("."))
   .settings(

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
@@ -1,7 +1,7 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
-lazy val reladomoV           = "16.5.1"
-lazy val twitterUtilCoreBinV  = "6.45"
+lazy val reladomoV           = "16.6.1"
+lazy val twitterUtilCoreBinV = "6.45"
 lazy val theOrganization     = "com.folio-sec"
 
 lazy val common = (project in file("common"))

--- a/version.sbt
+++ b/version.sbt
@@ -1,4 +1,4 @@
 import Dependencies.reladomoBinVersion
 
 //scripted-plugin requires SNAPSHOT version since it publishes to local ivy in every test runs
-version in ThisBuild := s"${reladomoBinVersion}.7-SNAPSHOT"
+version in ThisBuild := s"${reladomoBinVersion}.0-SNAPSHOT"


### PR DESCRIPTION
This pull request bumps Reladomo version to the latest on the master branch. I would like to work on the initial release for 16.6 series after merging this pull request.