### PR TITLE
Change supported twitter util version

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,7 +5,7 @@ object Dependencies {
 
   lazy val latestScalaVersion = "2.12.4"
 
-  lazy val twitterUtilVersion    = sys.env.get("TWITTER_UTIL_VERSION").getOrElse("6.45.0")
+  lazy val twitterUtilVersion    = sys.env.get("TWITTER_UTIL_VERSION").getOrElse("17.12.0")
   lazy val twitterUtilBinVersion = toBinV(twitterUtilVersion)
   lazy val reladomoVersion     = "16.6.1"
   lazy val reladomoBinVersion = toBinV(reladomoVersion)

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -4,6 +4,9 @@ import com.typesafe.tools.mima.plugin.MimaKeys.{mimaPreviousArtifacts, mimaRepor
 
 object MimaSettings {
 
+  // twitterUtilVersion which is not included in the previous reladomo-scala
+  val firstReleaseTwitterUtilVersions = Set("17.11.0", "17.12.0")
+
   // The `previousVersions` must be *ALL* the previous versions to be binary compatible (e.g. Set("16.6.0", "16.6.1") for "16.6.2-SNAPSHOT").
   // The following bad scenario is the reason we must obey the rule:
   //  - your build is toward 16.6.2 release and the `previousVersions` is "16.6.0" only
@@ -11,7 +14,7 @@ object MimaSettings {
   //  - you're going to remove some of the methods in 16.6.2
   //  - in this case, the incompatibility won't be detected
   // val previousVersions = Set.empty
-  val previousVersions = if(sys.env.get("TWITTER_UTIL_VERSION") == "17.12.0") {
+  val previousVersions = if(firstReleaseTwitterUtilVersions.contain(Dependencies.twitterUtilVersion)) {
     // because first release for this twitter util version, no binary compatbile check
     Set.empty
   } else {

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -14,7 +14,7 @@ object MimaSettings {
   //  - you're going to remove some of the methods in 16.6.2
   //  - in this case, the incompatibility won't be detected
   // val previousVersions = Set.empty
-  val previousVersions = if(firstReleaseTwitterUtilVersions.contain(Dependencies.twitterUtilVersion)) {
+  val previousVersions = if(firstReleaseTwitterUtilVersions.contains(Dependencies.twitterUtilVersion)) {
     // because first release for this twitter util version, no binary compatbile check
     Set.empty
   } else {

--- a/project/MimaSettings.scala
+++ b/project/MimaSettings.scala
@@ -10,8 +10,13 @@ object MimaSettings {
   //  - you've added new methods since 16.6.1
   //  - you're going to remove some of the methods in 16.6.2
   //  - in this case, the incompatibility won't be detected
-  val previousVersions = Set(0, 1).map(patch => s"16.6.$patch")
-  //val previousVersions = Set.empty
+  // val previousVersions = Set.empty
+  val previousVersions = if(sys.env.get("TWITTER_UTIL_VERSION") == "17.12.0") {
+    // because first release for this twitter util version, no binary compatbile check
+    Set.empty
+  } else {
+    Set(0, 1).map(patch => s"16.6.$patch")
+  }
 
   val mimaSettings = MimaPlugin.mimaDefaultSettings ++ Seq(
     mimaPreviousArtifacts := {

--- a/publish.sh
+++ b/publish.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 sbt clean "project reladomoScalaCommon" +publishSigned
-export TWITTER_UTIL_VERSION=6.43.0
-sbt clean "project reladomoScalaTwitterCommon" +publishSigned
-export TWITTER_UTIL_VERSION=6.45.0
-sbt clean "project reladomoScalaTwitterCommon" +publishSigned
-export TWITTER_UTIL_VERSION=7.0.0
-sbt clean "project reladomoScalaTwitterCommon" +publishSigned
 export TWITTER_UTIL_VERSION=7.1.0
 sbt clean "project reladomoScalaTwitterCommon" +publishSigned
 export TWITTER_UTIL_VERSION=17.10.0
+sbt clean "project reladomoScalaTwitterCommon" +publishSigned
+export TWITTER_UTIL_VERSION=17.11.0
+sbt clean "project reladomoScalaTwitterCommon" +publishSigned
+export TWITTER_UTIL_VERSION=17.12.0
 sbt clean "project reladomoScalaTwitterCommon" +publishSigned
 sbt clean "project sbtReladomoPlugin" "^publishSigned"

--- a/publish_local.sh
+++ b/publish_local.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
-sbt clean "project reladomoScalaCommon" +publishLocal 
-export TWITTER_UTIL_VERSION=6.43.0;sbt clean "project reladomoScalaTwitterCommon" +publishLocal
-export TWITTER_UTIL_VERSION=6.45.0;sbt clean "project reladomoScalaTwitterCommon" +publishLocal
-export TWITTER_UTIL_VERSION=7.0.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
+sbt clean "project reladomoScalaCommon" +publishLocal
 export TWITTER_UTIL_VERSION=7.1.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
 export TWITTER_UTIL_VERSION=17.10.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
+export TWITTER_UTIL_VERSION=17.11.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
+export TWITTER_UTIL_VERSION=17.12.0; sbt clean "project reladomoScalaTwitterCommon" +publishLocal
 
 sbt clean "project sbtReladomoPlugin" "^publishLocal"

--- a/sample/build.sbt
+++ b/sample/build.sbt
@@ -1,6 +1,6 @@
 lazy val reladomoScalaV  = sys.env.get("RELEASE_VERSION").getOrElse("16.6.2-SNAPSHOT")
 lazy val reladomoV       = "16.6.1"
-lazy val twitterBinV     = "17.12.0"
+lazy val twitterBinV     = "17.12"
 lazy val theOrganization = "com.folio-sec"
 
 lazy val root = (project in file("."))

--- a/sample/build.sbt
+++ b/sample/build.sbt
@@ -1,6 +1,6 @@
 lazy val reladomoScalaV  = sys.env.get("RELEASE_VERSION").getOrElse("16.6.2-SNAPSHOT")
 lazy val reladomoV       = "16.6.1"
-lazy val twitterBinV     = "6.45"
+lazy val twitterBinV     = "17.12.0"
 lazy val theOrganization = "com.folio-sec"
 
 lazy val root = (project in file("."))

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
@@ -1,7 +1,7 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
 lazy val reladomoV           = "16.6.1"
-lazy val twitterUtilCoreBinV = "17.12.0"
+lazy val twitterUtilCoreBinV = "17.12"
 lazy val theOrganization     = "com.folio-sec"
 
 lazy val root = (project in file("."))

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/generate-sources/build.sbt
@@ -1,7 +1,7 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
 lazy val reladomoV           = "16.6.1"
-lazy val twitterUtilCoreBinV = "6.45"
+lazy val twitterUtilCoreBinV = "17.12.0"
 lazy val theOrganization     = "com.folio-sec"
 
 lazy val root = (project in file("."))

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
@@ -1,7 +1,7 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
 lazy val reladomoV           = "16.6.1"
-lazy val twitterUtilCoreBinV = "6.45"
+lazy val twitterUtilCoreBinV = "17.12.0"
 lazy val theOrganization     = "com.folio-sec"
 
 lazy val common = (project in file("common"))

--- a/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
+++ b/sbt-reladomo-plugin/src/sbt-test/sbt-reladomo-gen/multi-sbt-projects/build.sbt
@@ -1,7 +1,7 @@
 import com.folio_sec.reladomo.generator.sbtplugin.ReladomoPlugin
 
 lazy val reladomoV           = "16.6.1"
-lazy val twitterUtilCoreBinV = "17.12.0"
+lazy val twitterUtilCoreBinV = "17.12"
 lazy val theOrganization     = "com.folio-sec"
 
 lazy val common = (project in file("common"))

--- a/travis.sh
+++ b/travis.sh
@@ -1,15 +1,13 @@
 #!/bin/bash
 if [[ ${TRAVIS_SCALA_VERSION} = "scripted-test" ]]; then
   sbt clean "project reladomoScalaCommon" +publishLocal \
+  && export TWITTER_UTIL_VERSION=17.12.0 \
+  && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
+  && export TWITTER_UTIL_VERSION=17.11.0 \
+  && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
   && export TWITTER_UTIL_VERSION=17.10.0 \
   && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
   && export TWITTER_UTIL_VERSION=7.1.0 \
-  && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
-  && export TWITTER_UTIL_VERSION=7.0.0 \
-  && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
-  && export TWITTER_UTIL_VERSION=6.45.0 \
-  && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
-  && export TWITTER_UTIL_VERSION=6.43.0 \
   && sbt clean "project reladomoScalaTwitterCommon" +publishLocal \
   && sbt clean \
       "project sbtReladomoPlugin" \


### PR DESCRIPTION
# The purpose / the description

support twitter_util 17.11, 17.12 & drop support 6.43,6.45,7.0

supporting versions policies are are not yet decided. 
I deleted some old versions at this stage. I think that support can be revived if there is a problem, please comment.

# Checklist for a pull request

- [x] Have you read [the guideline for contributors](https://github.com/folio-sec/reladomo-scala/blob/master/CONTRIBUTING.md)?
- [x] Do all the commits contain `Sign-off by: Full Name <email address>` line?
  - `git commit --signoff` or `git commit -s` that will add a line
