### PR TITLE
Re-enabling sbt-coursier

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
 libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value
 
-//addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.2")
+addSbtPlugin("io.get-coursier"   % "sbt-coursier"    % "1.0.2")
 addSbtPlugin("com.lucidchart"    % "sbt-scalafmt"    % "1.15")
 addSbtPlugin("com.typesafe"      % "sbt-mima-plugin" % "0.1.18")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"     % "0.3.3")


### PR DESCRIPTION
# The purpose / the description

Please check this pull request after merging https://github.com/folio-sec/reladomo-scala/pull/23

This pull request enables sbt-coursier again. As you may know, I've disabled it due to an uncontrollable issue on the Travis CI environment before.

https://github.com/folio-sec/reladomo-scala/commit/c7e45aa606dfb97f223178f04b44002c33c0693f

If we no longer have the issue with sbt-coursier 1.0.2, we can enable it again.

# Checklist for a pull request

- [x] Have you read [the guideline for contributors](https://github.com/folio-sec/reladomo-scala/blob/master/CONTRIBUTING.md)?
- [x] Do all the commits contain `Sign-off by: Full Name <email address>` line?
  - `git commit --signoff` or `git commit -s` that will add a line
